### PR TITLE
Fix invalid tile messages

### DIFF
--- a/src/OpenStreetMap-esp32.cpp
+++ b/src/OpenStreetMap-esp32.cpp
@@ -182,10 +182,9 @@ bool OpenStreetMap::resizeTilesCache(uint8_t numberOfTiles)
 
 void OpenStreetMap::updateCache(const tileList &requiredTiles, uint8_t zoom)
 {
-    const int32_t worldTileHeight = 1 << zoom;
     for (const auto &[x, y] : requiredTiles)
     {
-        if (y < 0 || y >= worldTileHeight)
+        if (y < 0 || y >= (1 << zoom))
             continue;
 
         if (!isTileCached(x, y, zoom))
@@ -219,12 +218,10 @@ bool OpenStreetMap::composeMap(LGFX_Sprite &mapSprite, const tileList &requiredT
         }
     }
 
-    const int32_t worldTileHeight = 1 << zoom;
-
     int tileIndex = 0;
     for (const auto &[tileX, tileY] : requiredTiles)
     {
-        if (tileY < 0 || tileY >= worldTileHeight)
+        if (tileY < 0 || tileY >= (1 << zoom))
         {
             tileIndex++;
             continue;

--- a/src/OpenStreetMap-esp32.cpp
+++ b/src/OpenStreetMap-esp32.cpp
@@ -219,7 +219,7 @@ bool OpenStreetMap::composeMap(LGFX_Sprite &mapSprite, const tileList &requiredT
         }
     }
 
-    const int32_t worldTileHeight = 1 << zoom; // Maximum valid tileY
+    const int32_t worldTileHeight = 1 << zoom;
 
     int tileIndex = 0;
     for (const auto &[tileX, tileY] : requiredTiles)

--- a/src/OpenStreetMap-esp32.cpp
+++ b/src/OpenStreetMap-esp32.cpp
@@ -182,8 +182,12 @@ bool OpenStreetMap::resizeTilesCache(uint8_t numberOfTiles)
 
 void OpenStreetMap::updateCache(const tileList &requiredTiles, uint8_t zoom)
 {
+    const int32_t worldTileHeight = 1 << zoom;
     for (const auto &[x, y] : requiredTiles)
     {
+        if (y < 0 || y >= worldTileHeight)
+            continue;
+
         if (!isTileCached(x, y, zoom))
         {
             const unsigned long startMs = millis();
@@ -215,9 +219,17 @@ bool OpenStreetMap::composeMap(LGFX_Sprite &mapSprite, const tileList &requiredT
         }
     }
 
+    const int32_t worldTileHeight = 1 << zoom; // Maximum valid tileY
+
     int tileIndex = 0;
     for (const auto &[tileX, tileY] : requiredTiles)
     {
+        if (tileY < 0 || tileY >= worldTileHeight)
+        {
+            tileIndex++;
+            continue;
+        }
+
         int drawX = startOffsetX + (tileIndex % numberOfColums) * OSM_TILESIZE;
         int drawY = startOffsetY + (tileIndex / numberOfColums) * OSM_TILESIZE;
 

--- a/src/OpenStreetMap-esp32.h
+++ b/src/OpenStreetMap-esp32.h
@@ -42,7 +42,7 @@ constexpr uint16_t OSM_TILE_TIMEOUT_MS = 500;
 constexpr uint16_t OSM_DEFAULT_CACHE_ITEMS = 10;
 constexpr uint16_t OSM_MAX_ZOOM = 18;
 
-using tileList = std::vector<std::pair<uint32_t, uint32_t>>;
+using tileList = std::vector<std::pair<uint32_t, int32_t>>;
 
 class OpenStreetMap
 {


### PR DESCRIPTION
Fix the issue that tiles with an invalid y index in the `requiredTiles` vector caused a lot of messages.  
These tiles are added when navigating around the polar areas -by design- and the resulting messages can be ignored.

Skipping these tiles in `updateCache` and `composeMap` while still updating `tileIndex` in `composeMap`solves the issue.