### PR TITLE
Fixed `attribution` bg and txt colors not set

### DIFF
--- a/src/OpenStreetMap-esp32.cpp
+++ b/src/OpenStreetMap-esp32.cpp
@@ -226,6 +226,7 @@ bool OpenStreetMap::composeMap(LGFX_Sprite &mapSprite, const tileList &requiredT
         tileIndex++;
     }
 
+    mapSprite.setTextColor(TFT_WHITE, TFT_BLACK);
     mapSprite.drawRightString(" Map data from OpenStreetMap.org ",
                               mapSprite.width(), mapSprite.height() - 10, &DejaVu9);
 


### PR DESCRIPTION
This PR fixes the issue that the `attribution` txt and bg colors were not set before adding the attribution to the map.