### PR TITLE
Fix `cacheSemaphore` leaking

### DIFF
--- a/src/OpenStreetMap-esp32.cpp
+++ b/src/OpenStreetMap-esp32.cpp
@@ -45,6 +45,9 @@ OpenStreetMap::~OpenStreetMap()
 
     freeTilesCache();
 
+    if (cacheSemaphore)
+        vSemaphoreDelete(cacheSemaphore);
+
     if (pngCore0)
     {
         pngCore0->~PNG();


### PR DESCRIPTION
Code is now leak free.

```
[Memory Stats Before Fetch]
Internal Free: 269748 bytes | Minimum Ever: 162556 bytes
PSRAM    Free: 5506296 bytes | Minimum Ever: 2897656 bytes
[ 19284][I][OpenStreetMap-esp32.cpp:611] startTileWorkerTasks(): Started 2 tile worker task(s)
[ 19294][I][OpenStreetMap-esp32.cpp:239] updateCache(): submitting 8 jobs
[ 22296][I][OpenStreetMap-esp32.cpp:255] updateCache(): Cache updated in 3002 ms

[Memory Stats Before Fetch]
Internal Free: 269748 bytes | Minimum Ever: 162348 bytes
PSRAM    Free: 5506296 bytes | Minimum Ever: 2897656 bytes
[ 22891][I][OpenStreetMap-esp32.cpp:611] startTileWorkerTasks(): Started 2 tile worker task(s)
[ 22901][I][OpenStreetMap-esp32.cpp:239] updateCache(): submitting 8 jobs
[ 25060][I][OpenStreetMap-esp32.cpp:255] updateCache(): Cache updated in 2159 ms

[Memory Stats Before Fetch]
Internal Free: 269748 bytes | Minimum Ever: 162348 bytes
PSRAM    Free: 5506296 bytes | Minimum Ever: 2897656 bytes
[ 25653][I][OpenStreetMap-esp32.cpp:611] startTileWorkerTasks(): Started 2 tile worker task(s)
[ 25663][I][OpenStreetMap-esp32.cpp:239] updateCache(): submitting 8 jobs
[ 27803][I][OpenStreetMap-esp32.cpp:255] updateCache(): Cache updated in 2140 ms

[Memory Stats Before Fetch]
Internal Free: 269748 bytes | Minimum Ever: 162348 bytes
PSRAM    Free: 5506296 bytes | Minimum Ever: 2897656 bytes
[ 28396][I][OpenStreetMap-esp32.cpp:611] startTileWorkerTasks(): Started 2 tile worker task(s)
[ 28406][I][OpenStreetMap-esp32.cpp:239] updateCache(): submitting 8 jobs
[ 30547][I][OpenStreetMap-esp32.cpp:255] updateCache(): Cache updated in 2141 ms

[Memory Stats Before Fetch]
Internal Free: 269748 bytes | Minimum Ever: 162348 bytes
PSRAM    Free: 5506296 bytes | Minimum Ever: 2897656 bytes
[ 31140][I][OpenStreetMap-esp32.cpp:611] startTileWorkerTasks(): Started 2 tile worker task(s)
[ 31150][I][OpenStreetMap-esp32.cpp:239] updateCache(): submitting 8 jobs
[ 33333][I][OpenStreetMap-esp32.cpp:255] updateCache(): Cache updated in 2183 ms
```